### PR TITLE
emphasize importance of 1st PC in plot

### DIFF
--- a/PCA.ipynb
+++ b/PCA.ipynb
@@ -343,6 +343,7 @@
     "\n",
     "# We plot normalized cumulative sum to understand the contributions of the obtained PCs\n",
     "plt.title('Normalized cumulative sum')\n",
+    "plt.ylim([0, 1.1])\n",
     "plt.xlabel('# principal components')\n",
     "plt.ylabel('cumulative sum')\n",
     "\n",


### PR DESCRIPTION
Matplotlib attaches the `ylim` to fit the data, i.e. sets it roughly to `[0.4, 1]`. This somehow "hides" the importance of 1st principal component (PC1). 
By plotting with the vertical axis ranging from the origin, the importance of PC1 is much more visible.